### PR TITLE
use libunicode to convert between latin1 and utf-8.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+1999-08-02  Robert Brady <rwb197@ecs.soton.ac.uk>
+
+	* encoding.c, Makefile.am: use libunicode to convert between latin1
+	  and utf-8.
+
 Tue Jul 27 21:43:00 CEST 1999 Daniel Veillard <Daniel.Veillard@w3.org>
 
         * xpath.[ch] : improvements and debug of the XPath implementation

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,11 +2,11 @@
 
 SUBDIRS = doc
 
-INCLUDES = -I@srcdir@ @CORBA_CFLAGS@ $(VERSION_FLAGS)
+INCLUDES = -I@srcdir@ @CORBA_CFLAGS@ $(VERSION_FLAGS)  `unicode-config --cflags`
 
 VERSION_FLAGS = -DLIBXML_VERSION=\"@LIBXML_VERSION@\"
 
-noinst_PROGRAMS=tester testSAX testHTML testXPath
+noinst_PROGRAMS=tester testSAX testHTML testXPath mytest
 
 bin_SCRIPTS=xml-config
 
@@ -44,12 +44,17 @@ xmlinc_HEADERS = \
 		valid.h
 
 DEPS = $(top_builddir)/libxml.la
-LDADDS = $(top_builddir)/libxml.la @Z_LIBS@
+LDADDS = $(top_builddir)/libxml.la @Z_LIBS@ `unicode-config --libs`
 
 tester_SOURCES=tester.c
 tester_LDFLAGS = 
 tester_DEPENDENCIES = $(DEPS)
 tester_LDADD= $(LDADDS)
+
+mytest_SOURCES=mytest.c
+mytest_LDFLAGS = 
+mytest_DEPENDENCIES = $(DEPS)
+mytest_LDADD= $(LDADDS)
 
 testSAX_SOURCES=testSAX.c
 testSAX_LDFLAGS = 


### PR DESCRIPTION
1999-08-02  Robert Brady <rwb197@ecs.soton.ac.uk>

	* encoding.c, Makefile.am: use libunicode to convert between latin1
	  and utf-8.